### PR TITLE
Fix typo.

### DIFF
--- a/content/MDP/monotonicity.pdc
+++ b/content/MDP/monotonicity.pdc
@@ -159,8 +159,8 @@ $$\sum_{x' \le y} \big[ P_{x^+ x'}(u^+) + P_{x^- x'}(u^-) \big]
   \sum_{x' \le y} \big[ P_{x^+ x'}(u^-) + P_{x^- x'}(u^+) \big]. $$
 which implies
 $$ \Pi(y) \ge M(y)$$
-where $\Pi$ and $M$ are the CDFs of $\pi$ and $\mu$. Thus, $\pi \succeq_s
-\mu$.
+where $\Pi$ and $M$ are the CDFs of $\pi$ and $\mu$. Thus, $\mu \succeq_s
+\pi$.
 
 Hence, for any weakly increasing function $v \colon \ALPHABET X \to \reals$,
 $$ \sum_{x' \in \ALPHABET X} \pi(x') v(x') \le 


### PR DESCRIPTION
Fixed typo regarding the stochastic dominance of the variables in the proof of Lemma regarding the conditions for C3.