### PR TITLE
Update certainty-equivalence.qmd

### DIFF
--- a/stochastic-optimization/certainty-equivalence.qmd
+++ b/stochastic-optimization/certainty-equivalence.qmd
@@ -37,7 +37,7 @@ We have that
 \\
 &= 
 \NORM{ a - w_\circ }_2^2 + \EXP[ \NORM{ w_\circ - W }_2^2 ]
-+ \EXP[ (a - w_\circ)^\TRANS (w_\circ - W) ]
++ 2 \EXP[ (a - w_\circ)^\TRANS (w_\circ - W) ]
 \\
 &=
 \NORM{ a - w_\circ }_2^2 + \EXP[ \NORM{ w_\circ - W }_2^2 ]


### PR DESCRIPTION
Proof holds without the 2, but it is clearer with it